### PR TITLE
fix(shim): avoid auto directive name collisions

### DIFF
--- a/ng_route_shim.js
+++ b/ng_route_shim.js
@@ -311,6 +311,7 @@
    * @param path – route configuration path
    * @returns {string|name} – a normalized (camelCase) directive name
    */
+  var autoCmpId = 0;
   function routeObjToRouteName(route, path) {
     var name = route.controllerAs;
 
@@ -328,7 +329,7 @@
     }
 
     if (name) {
-      name = name + 'AutoCmp';
+      name = name + (++autoCmpId) + 'AutoCmp';
     }
 
     return name;


### PR DESCRIPTION
I've fixed the shim directly for the sake of your demo and it seems to work fine.

See for the long-term solution: https://github.com/angular/angular/pull/4619
